### PR TITLE
Update runtime to 49

### DIFF
--- a/com.github.unrud.VideoDownloader.json
+++ b/com.github.unrud.VideoDownloader.json
@@ -1,7 +1,7 @@
 {
     "app-id": "com.github.unrud.VideoDownloader",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "47",
+    "runtime-version": "49",
     "sdk": "org.gnome.Sdk",
     "command": "video-downloader",
     "finish-args": [
@@ -23,16 +23,6 @@
         "*.la",
         "*.a"
     ],
-    "cleanup-commands": [
-        "mkdir -p /app/lib/ffmpeg"
-    ],
-    "add-extensions": {
-        "org.freedesktop.Platform.ffmpeg-full": {
-            "directory": "lib/ffmpeg",
-            "version": "24.08",
-            "add-ld-path": "."
-        }
-    },
     "modules": [
         {
             "name": "pyxattr",


### PR DESCRIPTION
FFmpeg does not have to be declared explicitly since Freedesktop runtime 25.08, which GNOME runtime 49 is based on